### PR TITLE
issue/2799 Switched to components.register

### DIFF
--- a/js/adapt-contrib-blank.js
+++ b/js/adapt-contrib-blank.js
@@ -1,8 +1,8 @@
-import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import BlankView from './blankView';
 import ComponentModel from 'core/js/models/componentModel';
 
-export default Adapt.register('blank', {
+export default components.register('blank', {
   model: ComponentModel.extend({}), // create a new class in the inheritance chain so it can be extended per component type if necessary later
   view: BlankView
 });


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Switched to `components.register` from `Adapt.register`