### PR TITLE
Fix: postRender automatically setting blank component as completed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/js/blankView.js
+++ b/js/blankView.js
@@ -8,7 +8,7 @@ export default class BlankView extends ComponentView {
 
   postRender() {
     this.setReadyStatus();
-    this.setCompletionStatus();
+    this.setupInviewCompletion();
   }
 
 }

--- a/js/blankView.js
+++ b/js/blankView.js
@@ -8,7 +8,7 @@ export default class BlankView extends ComponentView {
 
   postRender() {
     this.setReadyStatus();
-    this.setupInviewCompletion();
+    this.setCompletionStatus();
   }
 
 }

--- a/properties.schema
+++ b/properties.schema
@@ -14,7 +14,7 @@
     "_isOptional": {
       "type": "boolean",
       "required": false,
-      "default": false
+      "default": true
     },
   }
 }

--- a/properties.schema
+++ b/properties.schema
@@ -10,6 +10,11 @@
       "enum": ["full-width", "half-width", "both"],
       "default": "both",
       "editorOnly": true
-    }
+    },
+    "_isOptional": {
+      "type": "boolean",
+      "required": false,
+      "default": false
+    },
   }
 }

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -8,6 +8,15 @@
     },
     "with": {
       "properties": {
+        "_isOptional": {
+          "type": "boolean",
+          "default": true,
+          "isSetting": true,
+          "inputType": "Checkbox",
+          "validators": [],
+          "title": "Is this optional?",
+          "help": "An optional component does not have to be completed by the user."
+        },
         "_supportedLayout": {
           "type": "string",
           "title": "Supported layout",


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #45 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* postRender automatically setting blank component as completed on page view

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Create a course with blank components and page level progress
2. PLP should fill immediately on page load
3. Clicking PLP will show blank components individually have completed


