### PR TITLE
New: Remove default padding from Blank component (fixes #72)

### DIFF
--- a/less/blank.less
+++ b/less/blank.less
@@ -1,0 +1,3 @@
+.blank__inner {
+  padding: 0;
+}


### PR DESCRIPTION
Fixes #72

### New
* Add `less/blank.less` to remove default padding from `.blank__inner`

The Blank component is often used when an article or block should only have a header. The default component padding causes it to take up unnecessary space. This sets padding to 0 by default.

### Testing
1. Add a Blank component to a course
2. Verify the component no longer adds extra padding below the block/article header
3. Confirm no visual regression when Blank is used alongside other components

Posted via collaboration with Claude Code