### PR TITLE
Fix: Remove default padding from Blank component (fix #75)

### DIFF
--- a/less/blank.less
+++ b/less/blank.less
@@ -1,3 +1,3 @@
-.blank__inner {
+.blank .blank__inner {
   padding: 0;
 }


### PR DESCRIPTION
Fix #75 

### Fix
* Correctly removes default padding by making the selector more specific